### PR TITLE
Replace const with var

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -2,10 +2,10 @@
 
 'use strict'
 
-const arrayBufferToHex = require('array-buffer-to-hex')
+var arrayBufferToHex = require('array-buffer-to-hex')
 
 module.exports = function randomHex (bytes) {
-  const view = new Uint8Array(bytes)
+  var view = new Uint8Array(bytes)
 
   if (typeof crypto === 'object' && typeof crypto.getRandomValues === 'function') {
     crypto.getRandomValues(view)


### PR DESCRIPTION
For compatibility with older browsers.  iOS 8 does not support `cons`t, but this package advertises support for `iOS >= 7.1`
